### PR TITLE
Translate macros in loaded XML file only once

### DIFF
--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -41,6 +41,7 @@
 #include <epicsMutex.h>
 #include <epicsThread.h>
 #include <epicsExit.h>
+#include <macLib.h>
 
 //#import "LabVIEW.tlb" named_guids
 // The above statement would generate labview.tlh and labview.tli from an installed copy of LabVIEW, but we include pre-built versions in the source
@@ -108,8 +109,10 @@ private:
 	COAUTHIDENTITY* m_pidentity;
 	std::map<std::string,std::string> m_xpath_map;
 	std::map<std::string,bool> m_xpath_bool_map;
+	MAC_HANDLE *m_mac_env;
 
 	void DomFromCOM();
+	char* envExpand(const char *str);
 	void getViRef(BSTR vi_name, bool reentrant, LabVIEW::VirtualInstrumentPtr &vi);
 	void createViRef(BSTR vi_name, bool reentrant, LabVIEW::VirtualInstrumentPtr &vi);
 	void getLabviewValue(BSTR vi_name, BSTR control_name, VARIANT* value);


### PR DESCRIPTION
Now creates a macro cache based on the environment at load time,
so macros now only translated once. So we now have option for
special macros to be created by control program too.

To test, load an XML file containing a macro you define more than once,
whilst changing the macro inbetween. You can also change the macro on the
IOC command line and it should no longer alter things  

See ISISComputingGroup/IBEX#1277
