### PR TITLE
Ticket1695 lvdcom seci

### DIFF
--- a/MainPage.dox
+++ b/MainPage.dox
@@ -182,7 +182,7 @@ Typical LabVIEW.Application DCOM options to modify would be:
 </UL> 
 If you are running a 32bit LabVIEW on a 64bit computer, then you will not see LabVIEW listed if you just type <b>dcomcnfg</b> as there are separate 32 bit and 64 bit com registries. Instead you need to type:
 <PRE>
-cd C:\WINDOWS\SysWOW64
+cd C:\\WINDOWS\\SysWOW64
 mmc comexp.msc /32
 </PRE>
 See https://msdn.microsoft.com/en-us/library/windows/desktop/ms678426(v=vs.85).aspx for more details
@@ -200,7 +200,7 @@ can attempt to check/fix this using the procedure below but <B>changes to the wi
 
 Note that there are separate 32bit and 64 bit registries, if you are running 32bit %LabVIEW on a 64 bit computer you will not find LabVIEW.exe if you just run <b>regedit</b> - instead you need to:
 <PRE>
-cd C:\WINDOWS\SysWOW64
+cd C:\\WINDOWS\\SysWOW64
 regedit
 </PRE>
 

--- a/lvDCOMApp/Db/Makefile
+++ b/lvDCOMApp/Db/Makefile
@@ -10,7 +10,7 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------------------
 # Create and install (or just install)
 # databases, templates, substitutions like this
-#DB += lvDCOM.db
+DB += lvDCOM_boolean.template lvDCOM_string.template lvDCOM_int32.template lvDCOM_float64.template
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/lvDCOMApp/Db/lvDCOM_boolean.template
+++ b/lvDCOMApp/Db/lvDCOM_boolean.template
@@ -1,0 +1,19 @@
+record(bi, "$(P)$(PARAM)")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),0,0)$(RPARAM)")
+    field(SCAN, "$(SCAN)")
+    field(ZNAM, "$(ZNAME=0)")
+    field(ONAM, "$(ONAME=1)")
+}
+
+record(bo, "$(P)$(PARAM):SP")
+{
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),0,0)$(SPARAM)")
+    field(SCAN, "Passive")
+    field(ZNAM, "$(ZNAME=0)")
+    field(ONAM, "$(ONAME=1)")
+}
+
+#

--- a/lvDCOMApp/Db/lvDCOM_float64.template
+++ b/lvDCOMApp/Db/lvDCOM_float64.template
@@ -1,0 +1,17 @@
+record(ai, "$(P)$(PARAM)")
+{
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),0,0)$(RPARAM)")
+    field(SCAN, "$(SCAN)")
+    field(PREC, "3")
+}
+
+record(ao, "$(P)$(PARAM):SP")
+{
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),0,0)$(SPARAM)")
+    field(SCAN, "Passive")
+    field(PREC, "3")
+}
+
+#

--- a/lvDCOMApp/Db/lvDCOM_int32.template
+++ b/lvDCOMApp/Db/lvDCOM_int32.template
@@ -1,0 +1,15 @@
+record(longin, "$(P)$(PARAM)")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),0,0)$(RPARAM)")
+    field(SCAN, "$(SCAN)")
+}
+
+record(longout, "$(P)$(PARAM):SP")
+{
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),0,0)$(SPARAM)")
+    field(SCAN, "Passive")
+}
+
+#

--- a/lvDCOMApp/Db/lvDCOM_string.template
+++ b/lvDCOMApp/Db/lvDCOM_string.template
@@ -1,0 +1,35 @@
+record(stringin, "$(P)$(PARAM)")
+{
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),0,0)$(RPARAM)")
+    field(SCAN, "$(SCAN)")
+}
+
+record(stringout, "$(P)$(PARAM):SP")
+{
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),0,0)$(SPARAM)")
+    field(SCAN, "Passive")
+}
+
+# read
+record(waveform, "$(P)$(PARAM)WF")
+{
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),0,0)$(RPARAM)")
+    field(SCAN, "$(SCAN)")
+    field(FTVL, "CHAR")
+    field(NELM, 256)
+}
+
+# write
+record(waveform, "$(P)$(PARAM)WF:SP")
+{
+    field(DTYP, "asynOctetWrite")
+    field(INP,  "@asyn($(PORT),0,0)$(SPARAM)")
+    field(SCAN, "Passive")
+    field(FTVL, "CHAR")
+    field(NELM, 256)
+}
+
+#

--- a/lvDCOMApp/src/lvDCOMDriver.cpp
+++ b/lvDCOMApp/src/lvDCOMDriver.cpp
@@ -386,6 +386,9 @@ extern "C" {
 		registerStructuredExceptionHandler();
 		try
 		{
+			// need to specify both of these so we also get erstarted when labveie disppears (SECI restart / config change)
+			options |= static_cast<int>(lvDCOMOptions::lvNoStart);
+			options |= static_cast<int>(lvDCOMOptions::lvSECIConfig);
 			lvDCOMInterface* dcomint = new lvDCOMInterface("", "", host, 0x0, progid, username, password);
 			if (dcomint != NULL)
 			{

--- a/lvDCOMApp/src/lvDCOMDriver.cpp
+++ b/lvDCOMApp/src/lvDCOMDriver.cpp
@@ -43,7 +43,7 @@ static void seTransFunction(unsigned int u, EXCEPTION_POINTERS* pExp)
 	throw Win32StructuredException(u, pExp);
 }
 
-/// Register a handler for Win32 strcutured exceptions. This needs to be done on a per thread basis.
+/// Register a handler for Win32 structured exceptions. This needs to be done on a per thread basis.
 static void registerStructuredExceptionHandler()
 {
 	_set_se_translator(seTransFunction);
@@ -386,7 +386,7 @@ extern "C" {
 		registerStructuredExceptionHandler();
 		try
 		{
-			// need to specify both of these so we also get erstarted when labveie disppears (SECI restart / config change)
+			// need to specify both of these so we also get restarted when labview disappears (SECI restart / config change)
 			options |= static_cast<int>(lvDCOMOptions::lvNoStart);
 			options |= static_cast<int>(lvDCOMOptions::lvSECIConfig);
 			lvDCOMInterface* dcomint = new lvDCOMInterface("", "", host, 0x0, progid, username, password);

--- a/lvDCOMApp/src/lvDCOMDriver.cpp
+++ b/lvDCOMApp/src/lvDCOMDriver.cpp
@@ -374,6 +374,36 @@ extern "C" {
 		}
 	}
 
+	/// @param[in] portName @copydoc initArg0
+	/// @param[in] host @copydoc initArg1
+	/// @param[in] options @copydoc initArg2
+	/// @param[in] progid @copydoc initArg3
+	/// @param[in] username @copydoc initArg4
+	/// @param[in] password @copydoc initArg5
+	int lvDCOMSECIConfigure(const char *portName, const char* macros, const char* configSection, const char *configFile,
+	      const char* dbSubFile,const char *host, int options, const char* progid, const char* username, const char* password)
+	{
+		registerStructuredExceptionHandler();
+		try
+		{
+			lvDCOMInterface* dcomint = new lvDCOMInterface("", "", host, 0x0, progid, username, password);
+			if (dcomint != NULL)
+			{
+			    dcomint->generateFilesFromSECI(portName, macros, configSection, configFile, dbSubFile);
+			    return lvDCOMConfigure(portName, configSection, configFile, host, options, progid, username, password);
+			}
+			else
+			{
+				errlogSevPrintf(errlogFatal, "lvDCOMSECIConfigure failed (NULL)\n");
+				return(asynError);
+			}
+		}
+		catch(const std::exception& ex)
+		{
+			errlogSevPrintf(errlogFatal, "lvDCOMSECIConfigure failed: %s\n", ex.what());
+			return(asynError);
+		}
+	}
 	// EPICS iocsh shell commands 
 
 	static const iocshArg initArg0 = { "portName", iocshArgString};			///< A name for the asyn driver instance we will create - used to refer to it from EPICS DB files
@@ -385,6 +415,17 @@ extern "C" {
 	static const iocshArg initArg6 = { "username", iocshArgString};			///< (optional) remote username for \a host
 	static const iocshArg initArg7 = { "password", iocshArgString};			///< (optional) remote password for \a username on \a host
 
+	static const iocshArg initArgSECI0 = { "portName", iocshArgString};			///< A name for the asyn driver instance we will create - used to refer to it from EPICS DB files
+	static const iocshArg initArgSECI1 = { "macros", iocshArgString};	///< section name of \a configFile we will load 
+	static const iocshArg initArgSECI2 = { "configSection", iocshArgString};	///< section name of \a configFile settings from
+	static const iocshArg initArgSECI3 = { "configFile", iocshArgString};		///< Path to the XML input file to load configuration information from
+	static const iocshArg initArgSECI4 = { "dbSubFile", iocshArgString};		///< Path to the XML input file to load configuration information from
+	static const iocshArg initArgSECI5 = { "host", iocshArgString};				///< host name where LabVIEW is running ("" for localhost) 
+	static const iocshArg initArgSECI6 = { "options", iocshArgInt};			    ///< options as per #lvDCOMOptions enum
+	static const iocshArg initArgSECI7 = { "progid", iocshArgString};			///< (optional) DCOM ProgID (required if connecting to a compiled LabVIEW application)
+	static const iocshArg initArgSECI8 = { "username", iocshArgString};			///< (optional) remote username for \a host
+	static const iocshArg initArgSECI9 = { "password", iocshArgString};			///< (optional) remote password for \a username on \a host
+
 	static const iocshArg * const initArgs[] = { &initArg0,
 		&initArg1,
 		&initArg2,
@@ -394,17 +435,35 @@ extern "C" {
 		&initArg6,
 		&initArg7 };
 
-	static const iocshFuncDef initFuncDef = {"lvDCOMConfigure", sizeof(initArgs) / sizeof(iocshArg*), initArgs};
+	static const iocshArg * const initArgsSECI[] = { &initArgSECI0,
+		&initArgSECI1,
+		&initArgSECI2,
+		&initArgSECI3,
+		&initArgSECI4,
+		&initArgSECI5,
+		&initArgSECI6,
+		&initArgSECI7,
+		&initArgSECI8,
+		&initArgSECI9 };
+
+	static const iocshFuncDef initFuncDef = { "lvDCOMConfigure", sizeof(initArgs) / sizeof(iocshArg*), initArgs};
+	static const iocshFuncDef initFuncDefSECI = { "lvDCOMSECIConfigure", sizeof(initArgsSECI) / sizeof(iocshArg*), initArgsSECI};
 
 	static void initCallFunc(const iocshArgBuf *args)
 	{
 		lvDCOMConfigure(args[0].sval, args[1].sval, args[2].sval, args[3].sval, args[4].ival, args[5].sval, args[6].sval, args[7].sval);
 	}
 	
+	static void initCallFuncSECI(const iocshArgBuf *args)
+	{
+		lvDCOMSECIConfigure(args[0].sval, args[1].sval, args[2].sval, args[3].sval, args[4].sval, args[5].sval, args[6].ival, args[7].sval, args[8].sval, args[9].sval);
+	}
+
 	/// Register new commands with EPICS IOC shell
 	static void lvDCOMRegister(void)
 	{
 		iocshRegister(&initFuncDef, initCallFunc);
+		iocshRegister(&initFuncDefSECI, initCallFuncSECI);
 	}
 
 	epicsExportRegistrar(lvDCOMRegister);

--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -133,6 +133,7 @@ private:
     double getLabviewUptime();
 	std::string getLabviewValueType(BSTR vi_name, BSTR control_name);
 	void waitForLabVIEW();
+	void maybeWaitForLabVIEWOrExit();
 };
 
 #endif /* LV_DCOM_INTERFACE_H */

--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -71,7 +71,8 @@ enum lvDCOMOptions
 	viStartIfIdle = 2, 				///< (2)  If the LabVIEW VI is idle when we connect to it, attempt to start it
 	viStopOnExitIfStarted = 4, 		///< (4)  On IOC exit, stop any LabVIEW VIs that we started due to #viStartIfIdle being specified
 	viAlwaysStopOnExit = 8,			///< (8)  On IOC exit, stop any LabVIEW VIs that we have connected to
-	lvNoStart = 16                  ///< (16) Do not start LabVIEW, connect to existing instance otherwise fail. As loading a Vi starts labview, vis will not be loaded or started until a labview instance is detected
+	lvNoStart = 16,                  ///< (16) Do not start LabVIEW, connect to existing instance otherwise fail. As loading a Vi starts labview, vis will not be loaded or started until a labview instance is detected
+	lvSECIConfig = 32                  ///< (32) Automatically set if lvDCOMSECIConfigure() has been used
 };	
 
 /// Manager class for LabVIEW DCOM Interaction. Parses an @link lvinput.xml @endlink file and provides access to the LabVIEW VI controls/indicators described within. 

--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -67,10 +67,11 @@ struct ViRef
 /// In the iocBoot @link st.cmd @endlink file you will need to add the relevant integer enum values together and pass this single integer value.
 enum lvDCOMOptions
 {
-	viWarnIfIdle = 1, 				///< (1) If the LabVIEW VI is idle when we connect to it, issue a warning message  
-	viStartIfIdle = 2, 				///< (2) If the LabVIEW VI is idle when we connect to it, attempt to start it
-	viStopOnExitIfStarted = 4, 		///< (4) On IOC exit, stop any LabVIEW VIs that we started due to #viStartIfIdle being specified
-	viAlwaysStopOnExit = 8			///< (8) On IOC exit, stop any LabVIEW VIs that we have connected to
+	viWarnIfIdle = 1, 				///< (1)  If the LabVIEW VI is idle when we connect to it, issue a warning message  
+	viStartIfIdle = 2, 				///< (2)  If the LabVIEW VI is idle when we connect to it, attempt to start it
+	viStopOnExitIfStarted = 4, 		///< (4)  On IOC exit, stop any LabVIEW VIs that we started due to #viStartIfIdle being specified
+	viAlwaysStopOnExit = 8,			///< (8)  On IOC exit, stop any LabVIEW VIs that we have connected to
+	lvNoStart = 16                  ///< (16) Do not start LabVIEW, connect to existing instance otherwise fail. As loading a Vi starts labview, vis will not be loaded or started until a labview instance is detected
 };	
 
 /// Manager class for LabVIEW DCOM Interaction. Parses an @link lvinput.xml @endlink file and provides access to the LabVIEW VI controls/indicators described within. 
@@ -88,6 +89,8 @@ public:
 	std::string doXPATH(const std::string& xpath);
 	bool doXPATHbool(const std::string& xpath);
 	void report(FILE* fp, int details);
+	static double diffFileTimes(const FILETIME& f1, const FILETIME& f2);
+	void generateFilesFromSECI(const char* portName, const char* macros, const char* configSection, const char* configFile, const char* dbSubFile);
 
 private:
 	std::string m_configSection;  ///< section of \a configFile to load information from
@@ -97,6 +100,7 @@ private:
 	CLSID m_clsid;
 	std::string m_username;
 	std::string m_password;
+	static double m_minLVUptime; ///< minimum time labview must be running before connection made in "lvNoStart" mode
 	int m_options; ///< the various #lvDCOMOptions currently in use
 	typedef std::map<std::wstring, ViRef> vi_map_t;
 	vi_map_t m_vimap;
@@ -125,6 +129,8 @@ private:
 	static void epicsExitFunc(void* arg);
 	void stopVis(bool only_ones_we_started);
 	bool checkOption(lvDCOMOptions option) { return ( m_options & static_cast<int>(option) ) != 0; }
+    double getLabviewUptime();
+	std::string getLabviewValueType(BSTR vi_name, BSTR control_name);
 };
 
 #endif /* LV_DCOM_INTERFACE_H */

--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -132,6 +132,7 @@ private:
 	bool checkOption(lvDCOMOptions option) { return ( m_options & static_cast<int>(option) ) != 0; }
     double getLabviewUptime();
 	std::string getLabviewValueType(BSTR vi_name, BSTR control_name);
+	void waitForLabVIEW();
 };
 
 #endif /* LV_DCOM_INTERFACE_H */


### PR DESCRIPTION
Most of this PR relates to auto-generating lvDCOM config files on a SECI instrument via the new lvDCOMSECIConfigure() command. This is quite hard to test on an IBEX setup, so from the point of view of merging you should just check the new features and improved connection recovery for which you can use any existing lvdcom IOC:

- [x] Check that the IOC you chose still works as is 
- [x] Check the new lvNostart (16) lvDCOM option works on IOC startup with labview not running - the IOC should say "Waiting for LabVIEW" and wait until labview has been running 20 seconds
- [x] Check the new lvNostart (16) lvDCOM option works if labview is restarted while the IOC is running, the IOC should print a message about labview failure and say it cannot reconnect due to this option being specified
- [x] Check that if lvNostart (16) is not used, then restarting labview while the IOC is running will now reconnect correctly.

See ISISComputingGroup/IBEX#1695 and ISISComputingGroup/IBEX#1952 
