### PR TITLE
Reduce printing in lvdcom for SCIMAG3D zoom issues

### DIFF
--- a/lvDCOMApp/src/lvDCOMInterface.cpp
+++ b/lvDCOMApp/src/lvDCOMInterface.cpp
@@ -949,7 +949,10 @@ void lvDCOMInterface::createViRef(BSTR vi_name, bool reentrant, LabVIEW::Virtual
 		} 
 		std::cerr << "Successfully connected to local LabVIEW" << std::endl;
 	}
-	std::cerr << "Attemping to access \"" << CW2CT(vi_name) << "\" on " << (m_host.size() > 0 ? m_host : "localhost") << std::endl;
+        if (checkOption(lvDCOMVerbose))
+        {
+	    std::cerr << "Attempting to access \"" << CW2CT(vi_name) << "\" on " << (m_host.size() > 0 ? m_host : "localhost") << std::endl;
+        }
 	if (reentrant)
 	{
 		vi = m_lv->GetVIReference(vi_name, "", 1, 8);

--- a/lvDCOMApp/src/lvDCOMInterface.h
+++ b/lvDCOMApp/src/lvDCOMInterface.h
@@ -73,7 +73,8 @@ enum lvDCOMOptions
 	viAlwaysStopOnExit = 8,			///< (8)  On IOC exit, stop any LabVIEW VIs that we have connected to
 	lvNoStart = 16,                  ///< (16) Do not start LabVIEW, connect to existing instance otherwise fail. As loading a Vi starts labview, vis will not be loaded or started until a labview instance is detected. Automatically set for lvDCOMSECIConfigure() 
 	lvSECIConfig = 32,                  ///< (32) Automatically set if lvDCOMSECIConfigure() has been used
-	lvSECINoSetter = 64                  ///< (64) Do not generate setter XML / :SP PVs in SECI mode
+	lvSECINoSetter = 64,                  ///< (64) Do not generate setter XML / :SP PVs in SECI mode
+	lvDCOMVerbose = 128                   ///< (128) print extra messages
 };	
 
 /// Manager class for LabVIEW DCOM Interaction. Parses an @link lvinput.xml @endlink file and provides access to the LabVIEW VI controls/indicators described within. 


### PR DESCRIPTION
Reduce printing message that when SCIMAG3D is in a funny state causes 4GB / day error logs